### PR TITLE
Rng rewritten

### DIFF
--- a/src/crypto-asymmetric-dh.ads
+++ b/src/crypto-asymmetric-dh.ads
@@ -5,10 +5,11 @@ use Crypto.Types;
 
 generic
    Size : Positive;
+   Rand_Source : String := "";
 
 package Crypto.Asymmetric.DH is
 
-   package Big is new Crypto.Types.Big_Numbers(Size);
+   package Big is new Crypto.Types.Big_Numbers(Size, Rand_Source);
    use Big;
 
    subtype DH_Number is Bytes(0 .. Size/8 - 1);

--- a/src/crypto-asymmetric-dsa.ads
+++ b/src/crypto-asymmetric-dsa.ads
@@ -30,10 +30,11 @@ use Crypto.Types;
 
 generic
    Size : Positive;
+   Rand_Source : String := "";
 
 package Crypto.Asymmetric.DSA is
 
-   package Big is new Crypto.Types.Big_Numbers(Size);
+   package Big is new Crypto.Types.Big_Numbers(Size, Rand_Source);
    use Big;
 
    ---------------------------------------------------------------------------

--- a/src/crypto-asymmetric-ecdh.ads
+++ b/src/crypto-asymmetric-ecdh.ads
@@ -28,11 +28,12 @@ use Crypto.Types;
 
 generic
    Size : Positive;
+   Rand_Source : String := "";
 
 
 package Crypto.Asymmetric.ECDH is
 
-   package Big is new Crypto.Types.Big_Numbers(Size);
+   package Big is new Crypto.Types.Big_Numbers(Size, Rand_Source);
    use Big;
    package EC  is new Crypto.Types.Elliptic_Curves(Big);
    use EC;

--- a/src/crypto-asymmetric-ecdsa.ads
+++ b/src/crypto-asymmetric-ecdsa.ads
@@ -27,10 +27,11 @@ with Crypto.Types.Elliptic_Curves.Zp.Database;
 
 generic
    Size : Positive;
+   Rand_Source : String := "";
 
 package Crypto.Asymmetric.ECDSA is
 
-   package Big is new Crypto.Types.Big_Numbers(Size);
+   package Big is new Crypto.Types.Big_Numbers(Size, Rand_Source);
    use Big;
    package EC  is new Crypto.Types.Elliptic_Curves(Big);
    use EC;

--- a/src/crypto-types-big_numbers-mod_utils.adb
+++ b/src/crypto-types-big_numbers-mod_utils.adb
@@ -21,6 +21,7 @@
 -- executable file might be covered by the GNU Public License.
 
 with Crypto.Types.Random;
+with Crypto.Types.Random_Source.File;
 with Crypto.Asymmetric.Prime_Tables;
 --with Ada.Integer_Text_IO; use Ada.Integer_Text_IO;
 with Ada.Text_IO;
@@ -141,7 +142,12 @@ package body Mod_Utils is
 
    function Get_Random(N : Big_Unsigned) return Big_Unsigned is
       Result : Big_Unsigned;
+      Rand_Source_File : Random_Source.File.Random_Source_File;
    begin
+      if Rand_Source /= "" then
+         Random_Source.File.Initialize( Rand_Source_File, Rand_Source );
+         Random.Set(Rand_Source_File);
+      end if;
       Random.Read(Result.Number);
 
       for I in reverse 0..N.Last_Index loop

--- a/src/crypto-types-big_numbers-utils.adb
+++ b/src/crypto-types-big_numbers-utils.adb
@@ -23,6 +23,7 @@
 --with Ada.Integer_Text_IO;
 --with Ada.Strings.Unbounded.Text_IO;
 with Crypto.Types.Random;
+with Crypto.Types.Random_Source.File;
 
 SEPARATE(Crypto.Types.Big_Numbers)
 
@@ -296,7 +297,12 @@ package body Utils is
 
    function Get_Random return Big_Unsigned is
       Result : Big_Unsigned;
+      Rand_Source_File : Random_Source.File.Random_Source_File;
    begin
+      if Rand_Source /= "" then
+         Random_Source.File.Initialize( Rand_Source_File, Rand_Source );
+         Random.Set(Rand_Source_File);
+      end if;
       Random.Read(Result.Number);
       return Result;
    end Get_Random; pragma Inline (Get_Random);

--- a/src/crypto-types-big_numbers.ads
+++ b/src/crypto-types-big_numbers.ads
@@ -35,6 +35,7 @@ use Crypto.Types;
 
 generic
    Size : Positive;
+   Rand_Source : String := "";
 
 package Crypto.Types.Big_Numbers is
 

--- a/src/crypto-types-nonces-nonces_random.adb
+++ b/src/crypto-types-nonces-nonces_random.adb
@@ -1,11 +1,20 @@
 with Crypto.Types.Random;
+with Crypto.Types.Random_Source.File;
 
 package body Crypto.Types.Nonces.Nonces_Random is
    
    function Update(This: in out Nonce_Rand) return N.Block is
       Byte_Array: Crypto.Types.Bytes(0..(Block'Size / 8)-1);
       pragma Unreferenced (This);   
+      Rand_Source_File : Crypto.Types.Random_Source.File.Random_Source_File;
    begin     
+      if Rand_Source /= "" then
+         Crypto.Types.Random_Source.File.Initialize(
+            Rand_Source_File,
+            Rand_Source
+         );
+         Crypto.Types.Random.Set(Rand_Source_File);
+      end if;
       Crypto.Types.Random.Read(Byte_Array);
       return To_Block_Type(Byte_Array);
    end Update;

--- a/src/crypto-types-nonces-nonces_random.ads
+++ b/src/crypto-types-nonces-nonces_random.ads
@@ -2,6 +2,7 @@ with Crypto.Types;
 
 generic
    with function To_Block_Type(B: in Crypto.Types.Bytes) return Crypto.Types.Nonces.Block;
+   Rand_Source : String := "";
 
 package Crypto.Types.Nonces.Nonces_Random is
    package N renames Crypto.Types.Nonces;

--- a/src/crypto-types-nonces-nonces_randomized_counter.adb
+++ b/src/crypto-types-nonces-nonces_randomized_counter.adb
@@ -1,5 +1,6 @@
 with Crypto.Types;
 with Crypto.Types.Random;
+with Crypto.Types.Random_Source.File;
 with Ada.IO_Exceptions;
 
 package body Crypto.Types.Nonces.Nonces_Randomized_Counter is
@@ -28,6 +29,7 @@ package body Crypto.Types.Nonces.Nonces_Randomized_Counter is
       Result_Array  : Crypto.Types.Bytes(0..(Block'Size / 8)-1);
 
       Counter: Block;
+      Rand_Source_File : Crypto.Types.Random_Source.File.Random_Source_File;
    begin
       This.Mutex.Seize;
 
@@ -36,6 +38,13 @@ package body Crypto.Types.Nonces.Nonces_Randomized_Counter is
       Counter_Array := To_Bytes(Counter);
 
       -- get random numbers
+      if Rand_Source /= "" then
+         Crypto.Types.Random_Source.File.Initialize(
+            Rand_Source_File,
+            Rand_Source
+         );
+         Crypto.Types.Random.Set(Rand_Source_File);
+      end if;
       Crypto.Types.Random.Read(Rand_Array);
 
       -- fill result array (half counter, half random)

--- a/src/crypto-types-nonces-nonces_randomized_counter.ads
+++ b/src/crypto-types-nonces-nonces_randomized_counter.ads
@@ -7,6 +7,7 @@ generic
    Counter_Size: Positive := Block'Size / 16;
    with function To_Block_Type(Byte_Array: in Crypto.Types.Bytes) return Crypto.Types.Nonces.Block;
    with function To_Bytes(Block: in Crypto.Types.Nonces.Block) return Crypto.Types.Bytes;
+   Rand_Source : String := "";
 
 package Crypto.Types.Nonces.Nonces_Randomized_Counter is
 

--- a/src/crypto-types-random_source-file.adb
+++ b/src/crypto-types-random_source-file.adb
@@ -1,7 +1,7 @@
+with Ada.Streams.Stream_IO;
+
 package body Crypto.Types.Random_Source.File is
-   use Interfaces.C_Streams;
    use Ada.Strings.Unbounded;
-   use type Interfaces.C_Streams.Size_T;
 
    ---------------------------------------------------------------------------
    ------------------------ Initialization -----------------------------------
@@ -9,10 +9,7 @@ package body Crypto.Types.Random_Source.File is
    
    
    procedure Initialize(This : in out Random_Source_File) is
-      Cpath : constant String := "/dev/random" & ASCII.NUL;
-      Mode  : constant String := "r";   
    begin
-      This.Source_File := Fopen(Cpath'address, Mode'address);
       This.Source_Path := To_Unbounded_String("/dev/random");
    end Initialize;
    
@@ -20,10 +17,7 @@ package body Crypto.Types.Random_Source.File is
    
    procedure Initialize(This : in out Random_Source_File;
 			File_Path : in String) is
-      Cpath : constant String := File_Path & ASCII.NUL;
-      Mode  : constant String := "r";   
    begin
-      This.Source_File := Fopen(Cpath'address, Mode'address);
       This.Source_Path := To_Unbounded_String(File_Path);
    end Initialize;
    
@@ -33,22 +27,32 @@ package body Crypto.Types.Random_Source.File is
    
    
    procedure Read(This : in out Random_Source_File; B : out Byte) is 
-      I : Int;
+      Source_File : Ada.Streams.Stream_IO.File_Type;
    begin
-      I := fgetc(This.Source_File);
-      if  I < 0 then
-         raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path);
-      end if;
-      B := Byte(I);
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      Byte'Read( Ada.Streams.Stream_IO.Stream(Source_File), B );
+      Ada.Streams.Stream_IO.Close(Source_File);
    end Read;
    
    ---------------------------------------------------------------------------
       
    procedure Read(This : in out Random_Source_File; Byte_Array : out Bytes) is
-   begin  
-      if  Fread(Buffer => Byte_Array'address, Size => 1, Count => Byte_Array'Length, Stream => This.Source_File) /= Byte_Array'Length then
-         raise  RANDOM_SOURCE_READ_ERROR with  To_String(This.Source_Path);
-      end if;
+      Source_File : Ada.Streams.Stream_IO.File_Type;
+   begin
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      for I in Byte_Array'Range
+      loop
+         Byte'Read( Ada.Streams.Stream_IO.Stream(Source_File), Byte_Array(I) );
+      end loop;
+      Ada.Streams.Stream_IO.Close(Source_File);
    end Read;
    
    ---------------------------------------------------------------------------
@@ -63,20 +67,32 @@ package body Crypto.Types.Random_Source.File is
    ---------------------------------------------------------------------------
    
    procedure Read(This : in out Random_Source_File; W : out Word) is 
-   begin  
-      if Fread( Buffer => W'Address, Size => W'Size/8, Count => 1, 
-		Stream => This.Source_File ) /= 1 then
-	 raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path);
-      end if;
+      Source_File : Ada.Streams.Stream_IO.File_Type;
+   begin
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      Word'Read( Ada.Streams.Stream_IO.Stream(Source_File), W );
+      Ada.Streams.Stream_IO.Close(Source_File);
    end Read;
    
    ---------------------------------------------------------------------------
    
    procedure Read(This : in out Random_Source_File; Word_Array : out Words) is 
-   begin  
-      if Fread(Buffer => Word_Array'Address, Size => Word'Size/8, Count => Word_Array'Length, Stream => This.Source_File) /=  Word_Array'Length  then
-	 raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path);
-      end if;
+      Source_File : Ada.Streams.Stream_IO.File_Type;
+   begin
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      for I in Word_Array'Range
+      loop
+         Word'Read( Ada.Streams.Stream_IO.Stream(Source_File), Word_Array(I) );
+      end loop;
+      Ada.Streams.Stream_IO.Close(Source_File);
    end Read;
    
    ---------------------------------------------------------------------------
@@ -85,32 +101,30 @@ package body Crypto.Types.Random_Source.File is
    
 
    procedure Read(This : in out Random_Source_File; D : out DWord) is 
-   begin  
-      if  Fread( Buffer => D'Address, Size => D'Size/8, Count => 1, Stream => This.Source_File) /= 1 then
-         raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path);
-      end if;
-   end Read;
-   
-   procedure Read(This : in out Random_Source_File; DWord_Array : out DWords) is
-   begin  
-      if  Fread(Buffer => DWord_Array'Address, Size => DWord'Size/8,
-		Count => DWord_Array'Length, Stream => This.Source_File) /=  DWord_Array'Length then
-         raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path);
-      end if;      
-   end Read;
-   
-   
-   ---------------------------------------------------------------------------
-   ------------------------------- Finalize ----------------------------------
-   ---------------------------------------------------------------------------
-   
-   procedure Finalize(This : in out  Random_Source_File) is
+      Source_File : Ada.Streams.Stream_IO.File_Type;
    begin
-      if Fileno(This.Source_File) >= 0 then      	
-	 if  Fclose(This.Source_File) /= 0 then
-	    raise  RANDOM_SOURCE_READ_ERROR with To_String(This.Source_Path)
-	      &": can not close file.";
-	 end if;
-      end if;
-     end Finalize;
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      DWord'Read( Ada.Streams.Stream_IO.Stream(Source_File), D );
+      Ada.Streams.Stream_IO.Close(Source_File);
+   end Read;
+   
+   procedure Read(This : in out Random_Source_File; DWord_Array : out DWords) is 
+      Source_File : Ada.Streams.Stream_IO.File_Type;
+   begin
+      Ada.Streams.Stream_IO.Open(
+         Source_File, 
+         Ada.Streams.Stream_IO.In_File, 
+         To_String(This.Source_Path)
+      );
+      for I in DWord_Array'Range
+      loop
+         DWord'Read( Ada.Streams.Stream_IO.Stream(Source_File), DWord_Array(I) );
+      end loop;
+      Ada.Streams.Stream_IO.Close(Source_File);
+   end Read;
+
 end Crypto.Types.Random_Source.File;

--- a/src/crypto-types-random_source-file.ads
+++ b/src/crypto-types-random_source-file.ads
@@ -1,4 +1,3 @@
-with Interfaces.C_Streams;
 with Ada.Strings.Unbounded;
 
 package Crypto.Types.Random_Source.File is
@@ -6,9 +5,6 @@ package Crypto.Types.Random_Source.File is
 
    type Random_Source_File is new Rnd.Random_Source with private;
    type Random_Source_File_Access is access  Random_Source_File;
-   
-   Overriding
-   procedure Finalize(This : in out  Random_Source_File);
    
    Overriding
    procedure Initialize(This : in out Random_Source_File);
@@ -39,6 +35,5 @@ private
    type Random_Source_File is new Rnd.Random_Source with
       record
 	 Source_Path : Ada.Strings.Unbounded.Unbounded_String;
-	 Source_File : Interfaces.C_Streams.Files;
       end record;
 end Crypto.Types.Random_Source.File;


### PR DESCRIPTION
Rewrote the RNG parts. Now it uses Ada's own Stream_IO package instead of calling C functions. It's also rewritten so the stream is opened only on request, i.e. when information needs to be read from the RNG source file. This is achieved by opening and closing the the source file during the Read procedures, not during Initialize and Finalize respectively. 

Moreover Big_Numbers and random Nonces was changed to add the ability to use a different RNG source than the default one from the Random package (i.e. /dev/random). When instantiating e.g. Big_Numbers an optional string signifies the RNG source file. 

Lastly added generic instantiation variable to all asymmetric algorithms so non-default RNGs can be used by them as well. 