### PR TITLE
Generation of CRT form of RSA keys

### DIFF
--- a/doc/en/acl.crypto.asymmetric.rsa.tex
+++ b/doc/en/acl.crypto.asymmetric.rsa.tex
@@ -33,17 +33,25 @@ byte and the last element ($'Last$) corresponds the least significant
 byte of the array.\\
 \begin{lstlisting}{}
   type Public_Key_RSA is record
-    N : Big_Unsigned;
-    E : Big_Unsigned;
+    N : Big_Unsigned; -- Modulus
+    E : Big_Unsigned; -- Public exponent
   end record;
   type Private_Key_RSA is record
-    N : Big_Unsigned;
-    D : Big_Unsigned;
-    Phi : Big_Unsigned;
+    N    : Big_Unsigned; -- Modulus = p * q
+    D    : Big_Unsigned; -- private exponent = (e ^ -1) mod Phi
+    P    : Big_Unsigned; -- prime p
+    Q    : Big_Unsigned; -- prime q
+    Phi  : Big_Unsigned; -- = (p - 1) * (q - 1)
+
+    --  Chinese Remainder Theory (CRT) forms of the
+    --  private exponent
+    DP   : Big_Unsigned; -- = d mod (p - 1)
+    DQ   : Big_Unsigned; -- = d mod (q - 1)
+    QInv : Big_Unsigned; -- = (q ^ -1) mod p
   end record;
 \end{lstlisting}
 The term \texttt{Public\_Key\_RSA} has two components, and
-\texttt{Private\_Key\_RSA} has three components. They are used in
+\texttt{Private\_Key\_RSA} has eight components. They are used in
 internal functions to generate key pairs.\\
 \subsubsection*{High-Level-API}
 \begin{lstlisting}{}
@@ -129,17 +137,24 @@ The public key can be reconstructed later with those two components.
 
 \hhline
 \begin{lstlisting}{}
-  procedure Get_Private_Key(Private_Key : in Private_Key_RSA;
-                            N           : out RSA_Number;
-                            D           : out RSA_Number;
-                            Phi         : out RSA_Number);
+  procedure Get_Private_Key (Private_Key : in Private_Key_RSA;
+                             N           : out RSA_Number;
+                             D           : out RSA_Number;
+                             P           : out RSA_Number;
+                             Q           : out RSA_Number;
+                             Phi         : out RSA_Number;
+                             DP          : out RSA_Number;
+                             DQ          : out RSA_Number;
+                             QInv        : out RSA_Number;
 \end{lstlisting}
 The procedure decomposes a private key (\texttt{Private\_Key}) into
 the following components:
 \begin{itemize}
 \item One size-bit RSA modulus $N$ where $N=PQ$, $P,Q$ are prime numbers
 \item One private RSA exponent $D$
+\item Primes $P$ and $Q$
 \item $\phi(N)=(P-1)(Q-1)$
+\item Chinese Remainder Theory (CRT) forms of the private exponent $DP$, $DQ$, and $QInv$
 \end{itemize}
 The private key can be reconstructed later with those components.
 
@@ -165,28 +180,37 @@ smaller than 3 :\quad \texttt{Constraint\_Error}.
 \begin{lstlisting}{}
   procedure Set_Private_Key(N           : in RSA_Number;
                             D           : in RSA_Number;
+                            P           : in RSA_Number;
+                            Q           : in RSA_Number;
                             Phi         : in RSA_Number;
                             Private_Key : out Private_Key_RSA);
   procedure Set_Private_Key(N           : in Big_Unsigned;
                             D           : in Big_Unsigned;
+                            P           : in Big_Unsigned;
+                            Q           : in Big_Unsigned;
                             Phi         : in Big_Unsigned;
                             Private_Key : out Private_Key_RSA);
 \end{lstlisting}
 The two procedures can both be used to (re-)construct a private
 key. The following values are required as parameters:
 \begin{itemize}
-\item One size-bit RSA modulus $N$ where $N=PQ$, $P,Q$ prime numbers
+\item One size-bit RSA modulus $N$ where $N=PQ$,
+\item Prime numbers $P$ and $Q$
 \item One private RSA exponent $D$
 \item $\phi(N)=(P-1)(Q-1)$
 \end{itemize}
-\textbf{Exception:}\\ If one of the following conditions about the
+The CRT forms of the private exponent are computed from $P$, $Q$, and $D$.
+
+\noindent\textbf{Exception:}\\ If one of the following conditions about the
 private key is met, then a \texttt{Constraint\_Error} is raised:
 \begin{itemize}
 \item the length of $N$ is not equal the \texttt{Size}\,,
+\item $P$ less than or equal to $Q$
 \item the term $D$ is even, or its bit value is smaller than or equal 2\,,
 \item the term $\phi(N)$ is odd, or its length is smaller than
   \texttt{Size}-2\,,
 \item the greatest common divisor of $D$ and $\phi(N)$ is not 1\,.
+\item RCC notes this GCD rule does not match the code.  Bug?
 \end{itemize}
 
 \subsubsection*{Low-Level-API}

--- a/src/crypto-asymmetric-rsa.adb
+++ b/src/crypto-asymmetric-rsa.adb
@@ -59,15 +59,27 @@ package body Crypto.Asymmetric.RSA is
 
    ---------------------------------------------------------------------------
 
-   function Check_Private_Key(X : Private_Key_RSA) return Boolean is
+   function Check_Private_Key(X : Private_Key_RSA) return Boolean
+   is
+      P1 : constant Big_Unsigned := X.P - 1;
+      Q1 : constant Big_Unsigned := X.Q - 1;
    begin
-      if Bit_Length(X.N) < Size-1 or Is_Even(X.D) or (Bit_Length(X.Phi) < Size-2)
-        or X.P*X.Q /= X.N or (X.P-1)*(X.Q-1) /= X.Phi or Gcd(X.D, X.P) /= 1
-	or Gcd(X.D, X.Q) /= Big_Unsigned_One then
-	 return False;
-      else
-	 return True;
-      end if;
+      return
+	Bit_Length (X.N) >= (Size - 1) and
+	(Bit_Length (X.Phi) >= (Size - 2)) and
+
+	Is_Odd (X.D) and
+
+	X.P    > X.Q and
+
+        X.N    = X.P * X.Q and
+	X.Phi  = P1 * Q1 and
+	X.DP   = X.D mod P1 and
+	X.DQ   = X.D mod Q1 and
+	X.QInv = Inverse (X.Q, X.P) and
+
+	Gcd (X.D, X.P) = 1 and
+	Gcd (X.D, X.Q) = Big_Unsigned_One;
    end Check_Private_Key; pragma Inline(Check_Private_Key);
 
    ---------------------------------------------------------------------------
@@ -76,7 +88,9 @@ package body Crypto.Asymmetric.RSA is
                       Private_Key              :    out Private_Key_RSA;
 		      Small_Default_Exponent_E : in     Boolean := True)
    is
-      P, Q, N, Phi, E, D : Big_Unsigned;
+      P, Q, N, Phi, E, D, DP, DQ, QInv : Big_Unsigned;
+
+      P1, Q1 : Big_Unsigned;
 
       --  Phi must be set before Find_E can be called.
       function Find_E return Big_Unsigned
@@ -99,7 +113,8 @@ package body Crypto.Asymmetric.RSA is
 	 loop
 	    Possible_E := Get_Random (Phi);
 
-	    if Gcd (Possible_E, Phi) = Big_Unsigned_One and Possible_E > 65536 then
+	    if Gcd (Possible_E, Phi) = Big_Unsigned_One and
+	      Possible_E > 65536 then
 	       return Possible_E;
 	    end if;
 	 end loop;
@@ -118,19 +133,31 @@ package body Crypto.Asymmetric.RSA is
 	 Swap (P, Q);
       end if;
 
+
+      P1 := P - 1;
+      Q1 := Q - 1;
+
       N   := P * Q;
-      Phi := (P - 1) * (Q - 1);
+      Phi := P1 * Q1;
       E   := Find_E;
       D   := Inverse (E, Phi);
+
+      DP := D mod P1;
+      DQ := D mod Q1;
+      QInv := Inverse (Q, P);
 
       Public_Key := Public_Key_RSA'(N => N,
                                     E => E);
 
-      Private_Key := Private_Key_RSA'(N   => N,
-				      D   => D,
-				      P   => P,
-				      Q   => Q,
-				      Phi => Phi);
+      -- Named association here to avoid order dependent defect
+      Private_Key := Private_Key_RSA'(N    => N,
+				      D    => D,
+				      P    => P,
+				      Q    => Q,
+				      Phi  => Phi,
+				      DP   => DP,
+				      DQ   => DQ,
+				      QInv => QInv);
    end Gen_Key;
 
    ---------------------------------------------------------------------------
@@ -220,24 +247,50 @@ package body Crypto.Asymmetric.RSA is
 
    ---------------------------------------------------------------------------
 
-   procedure Get_Private_Key(Private_Key : in Private_Key_RSA;
-                             N   : out RSA_Number;
-                             D   : out RSA_Number;
-                             P   : out RSA_Number;
-                             Q   : out RSA_Number;
-                             Phi : out RSA_Number) is
+   procedure Get_Private_Key (Private_Key : in     Private_Key_RSA;
+                              N           :    out RSA_Number;
+                              D           :    out RSA_Number;
+                              P           :    out RSA_Number;
+                              Q           :    out RSA_Number;
+                              Phi         :    out RSA_Number;
+                              DP          :    out RSA_Number;
+                              DQ          :    out RSA_Number;
+                              QInv        :    out RSA_Number)
+   is
+      DPByteL : constant Natural := Length_In_Bytes (Private_Key.DP);
+      DPBytes : constant Bytes   := To_Bytes (Private_Key.DP);
+
+      DQByteL : constant Natural := Length_In_Bytes (Private_Key.DQ);
+      DQBytes : constant Bytes   := To_Bytes (Private_Key.DQ);
+
+      QInvByteL : constant Natural := Length_In_Bytes (Private_Key.QInv);
+      QInvBytes : constant Bytes   := To_Bytes (Private_Key.QInv);
    begin
       N := To_Bytes(Private_Key.N);
+      
       D := (others => 0);
       D(D'Last - (Length_In_Bytes(Private_Key.D) - 1)..D'Last)
         := To_Bytes(Private_Key.D);
+      
       P := (others => 0);
       P(P'Last - (Length_In_Bytes(Private_Key.P) - 1)..P'Last)
         := To_Bytes(Private_Key.P);
+      
       Q := (others => 0);
       Q(Q'Last - (Length_In_Bytes(Private_Key.Q) - 1)..Q'Last)
         := To_Bytes(Private_Key.Q);
+      
       Phi := To_Bytes(Private_Key.Phi);
+
+      DP := (others => 0);
+      DP (DP'Last - (DPByteL - 1) .. DP'Last) := DPBytes;
+
+      DQ := (others => 0);
+      DQ (DQ'Last - (DQByteL - 1) .. DQ'Last) := DQBytes;
+
+      QInv := (others => 0);
+      QInv (QInv'Last - (QInvByteL - 1) .. QInv'Last) := QInvBytes;
+
    end Get_Private_Key;
 
    ---------------------------------------------------------------------------
@@ -265,20 +318,35 @@ package body Crypto.Asymmetric.RSA is
    ---------------------------------------------------------------------------
 
 
-   procedure Set_Private_Key(N   : in RSA_Number;
-                             D   : in RSA_Number;
-                             P   : in RSA_Number;
-                             Q   : in RSA_Number;
-                             Phi : in RSA_Number;
-                             Private_Key : out Private_Key_RSA) is
+   procedure Set_Private_Key
+     (N           : in     RSA_Number;
+      D           : in     RSA_Number;
+      P           : in     RSA_Number;
+      Q           : in     RSA_Number;
+      Phi         : in     RSA_Number;
+      Private_Key :    out Private_Key_RSA)
+   is
+      DL, PL, P1, QL, Q1 : Big_Unsigned;
    begin
-      Private_Key.N := To_Big_Unsigned(N);
-      Private_Key.D := To_Big_Unsigned(D);
-      Private_Key.P := To_Big_Unsigned(P);
-      Private_Key.Q := To_Big_Unsigned(Q);
-      Private_Key.Phi := To_Big_Unsigned(Phi);
+      PL := To_Big_Unsigned (P);
+      P1 := PL - 1;
 
-      if not(Check_Private_Key(Private_Key)) then
+      QL := To_Big_Unsigned (Q);
+      Q1 := QL - 1;
+
+      DL := To_Big_Unsigned (D);
+
+      Private_Key := Private_Key_RSA'
+	(N    => To_Big_Unsigned(N),
+         D    => DL,
+         P    => PL,
+         Q    => QL,
+         Phi  => To_Big_Unsigned(Phi),
+         DP   => DL mod P1,
+         DQ   => DL mod Q1,
+         QInv => Inverse (QL, PL));
+	
+      if not (Check_Private_Key (Private_Key)) then
          raise  Constraint_Error;
       end if;
    end Set_Private_Key;
@@ -291,15 +359,24 @@ package body Crypto.Asymmetric.RSA is
                              P   : in Big_Unsigned;
                              Q   : in Big_Unsigned;
                              Phi : in Big_Unsigned;
-                             Private_Key : out Private_Key_RSA) is
+                             Private_Key : out Private_Key_RSA)
+   is
+      P1, Q1 : Big_Unsigned;
    begin
-      Private_Key.N := N;
-      Private_Key.D := D;
-      Private_Key.P := P;
-      Private_Key.Q := Q;
-      Private_Key.Phi := Phi;
+      P1 := P - 1;
+      Q1 := Q - 1;
 
-      if not(Check_Private_Key(Private_Key)) then
+      Private_Key := Private_Key_RSA'
+	(N    => N,
+         D    => D,
+         P    => P,
+         Q    => Q,
+         Phi  => Phi,
+         DP   => D mod P1,
+         DQ   => D mod Q1,
+         QInv => Inverse (Q, P));
+	
+      if not (Check_Private_Key (Private_Key)) then
 	raise  Constraint_Error;
       end if;
    end Set_Private_Key;

--- a/src/crypto-asymmetric-rsa.ads
+++ b/src/crypto-asymmetric-rsa.ads
@@ -79,16 +79,19 @@ package Crypto.Asymmetric.RSA is
 
    -- Phi = (P-1) * (Q-1); N = PQ;  ED = 1 (mod Phi)
 
-   procedure Get_Public_Key(Public_Key : in Public_Key_RSA;
-                            N : out RSA_Number;
-                            E : out RSA_Number);
+   procedure Get_Public_Key (Public_Key : in     Public_Key_RSA;
+                             N          :    out RSA_Number;
+                             E          :    out RSA_Number);
 
-   procedure Get_Private_Key(Private_Key : in Private_Key_RSA;
-                             N   : out RSA_Number;
-                             D   : out RSA_Number;
-                             P   : out RSA_Number;
-                             Q   : out RSA_Number;
-                             Phi : out RSA_Number);
+   procedure Get_Private_Key (Private_Key : in     Private_Key_RSA;
+                              N           :    out RSA_Number;
+                              D           :    out RSA_Number;
+                              P           :    out RSA_Number;
+                              Q           :    out RSA_Number;
+                              Phi         :    out RSA_Number;
+                              DP          :    out RSA_Number;
+                              DQ          :    out RSA_Number;
+                              QInv        :    out RSA_Number);
 
 
    ---------------------------------------------------------------------------
@@ -102,13 +105,20 @@ package Crypto.Asymmetric.RSA is
                             Public_Key : out Public_Key_RSA);
 
 
-   procedure Set_Private_Key(N   : in RSA_Number;
-                             D   : in RSA_Number;
-			     P   : in RSA_Number;
-			     Q   : in RSA_Number;
-                             Phi : in RSA_Number;
-                             Private_Key : out Private_Key_RSA);
+   --  Set Private_Key with CRT components DP, DQ and QInv
+   --  computed from P, Q, and D.
+   --
+   --  If N, D, P, Q and Phi do not form a valid key, then
+   --  Constraint_Error is raised.
+   procedure Set_Private_Key
+     (N           : in     RSA_Number;
+      D           : in     RSA_Number;
+      P           : in     RSA_Number;
+      Q           : in     RSA_Number;
+      Phi         : in     RSA_Number;
+      Private_Key :    out Private_Key_RSA);
 
+   --  As above, overloaded for Big_Unsigned parameters
    procedure Set_Private_Key(N   : in Big_Unsigned;
                              D   : in Big_Unsigned;
 			     P   : in Big_Unsigned;
@@ -142,16 +152,22 @@ package Crypto.Asymmetric.RSA is
 
 private
    type Public_Key_RSA is record
-      N : Big_Unsigned;
-      E : Big_Unsigned;
+      N : Big_Unsigned; -- Modulus
+      E : Big_Unsigned; -- Public exponent
    end record;
 
    type Private_Key_RSA is record
-      N : Big_Unsigned;
-      D : Big_Unsigned;
-      P : Big_Unsigned;
-      Q : Big_Unsigned;
-      Phi : Big_Unsigned; --= p-1*q-1
+      N    : Big_Unsigned; -- Modulus = p * q
+      D    : Big_Unsigned; -- private exponent = (e ^ -1) mod Phi
+      P    : Big_Unsigned; -- prime p
+      Q    : Big_Unsigned; -- prime q
+      Phi  : Big_Unsigned; -- = (p - 1) * (q - 1)
+
+      --  Chinese Remainder Theory (CRT) forms of the
+      --  private exponent
+      DP   : Big_Unsigned; -- = d mod (p - 1)
+      DQ   : Big_Unsigned; -- = d mod (q - 1)
+      QInv : Big_Unsigned; -- = (q ^ -1) mod p
    end record;
 
    pragma Optimize (Time);

--- a/src/crypto-asymmetric-rsa.ads
+++ b/src/crypto-asymmetric-rsa.ads
@@ -46,9 +46,9 @@ package Crypto.Asymmetric.RSA is
    --------------------------HIGH LEVEL API-----------------------------------
    ---------------------------------------------------------------------------
 
-   procedure Gen_Key(Public_Key  : out Public_Key_RSA;
-                     Private_Key : out Private_Key_RSA;
-		     Small_Default_Exponent_E : in Boolean := True);
+   procedure Gen_Key (Public_Key               :    out Public_Key_RSA;
+                      Private_Key              :    out Private_Key_RSA;
+                      Small_Default_Exponent_E : in     Boolean := True);
 
    ---------------------------------------------------------------------------
 

--- a/src/crypto-asymmetric-rsa.ads
+++ b/src/crypto-asymmetric-rsa.ads
@@ -77,7 +77,7 @@ package Crypto.Asymmetric.RSA is
 
    ---------------------------------------------------------------------------
 
-   -- N = (P-1) * (Q-1); N = PQ;  ED = 1 (mod Phi)
+   -- Phi = (P-1) * (Q-1); N = PQ;  ED = 1 (mod Phi)
 
    procedure Get_Public_Key(Public_Key : in Public_Key_RSA;
                             N : out RSA_Number;

--- a/src/crypto-types-big_numbers-mod_utils.adb
+++ b/src/crypto-types-big_numbers-mod_utils.adb
@@ -428,26 +428,29 @@ package body Mod_Utils is
          raise Constraint_Error;
       end if;
 
-
       loop
          -- Make sure that Result is an odd
-         Set_Least_Significant_Bit(Result);
+         Set_Least_Significant_Bit (Result);
 
          -- Make sure that Result is a N-Bit-Number;
-         Result.Number(Index) :=  Result.Number(Index) or
-           Shift_Left(Word(1), Amount);
-         if Amount = 0 then Result.Last_Index := Index;
+         Result.Number (Index) := Result.Number (Index) or
+           Shift_Left (Word (1), Amount);
+
+         if Amount = 0 then
+	    Result.Last_Index := Index;
          end if;
 
-         if Is_Prime(Result) then return Result;
+         if Is_Prime(Result) then
+	    return Result;
          else
             Result:=Result-2;
-            if Is_Prime(Result) then return Result;
+            if Is_Prime(Result) then 
+	       return Result;
             end if;
          end if;
 
-         J  := Get_Random(Shift_Left(Big_Unsigned_One,N-2));
-         Result := Shift_Left(J,1);
+         J := Get_Random (Shift_Left (Big_Unsigned_One, N - 2));
+         Result := Shift_Left (J, 1);
       end loop;
 
    end Get_N_Bit_Prime;

--- a/src/crypto-types-big_numbers-utils.adb
+++ b/src/crypto-types-big_numbers-utils.adb
@@ -551,17 +551,19 @@ package body Utils is
    ---------------------------------------------------------------------------
 
    function To_String(Item : Big_Unsigned;
-                                   Base : Number_Base := 10) return String is
+                      Base : Number_Base := 10) return String is
       S  : Unbounded_String  := Null_Unbounded_String;
       Remainder : Word:=0;
       Temp_Item : Big_Unsigned := Item;
       Trans : constant array(Word range 0..15) of Character :=
         ('0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F');
+      Base_Img : constant String := Base'Img;
    begin
       if Item = Big_Unsigned_Zero then
          if Base = 10 then  return "0";
          else
-            S := Base'Img & "#0#" & S;
+	    S := "#0#" & S;
+            S := Base_Img & S;
             return Slice(S,2,Length(S));
          end if;
       else
@@ -574,7 +576,7 @@ package body Utils is
          end loop;
          if Base /= 10 then
             S := "#" & S;
-            S := Base'Img & S;
+            S := Base_Img & S;
             return Slice(S,2,Length(S));
          end if;
       end if;

--- a/test/test-rsa.adb
+++ b/test/test-rsa.adb
@@ -75,6 +75,41 @@ package body Test.RSA is
   
    Phi: constant Big_Unsigned := (P-1) * (Q-1);
 
+
+   --  References values for DP, DQ and QInv generated from P and Q
+   --  using the tools at:
+   --  http://www.mobilefish.com/services/rsa_key_generation/rsa_key_generation.php
+   DP   : constant Big_Unsigned := To_Big_Unsigned
+     ("16#0e_12_bf_17_18_e9_ce_f5" &
+         "59_9b_a1_c3_88_2f_e8_04" &
+	 "6a_90_87_4e_ef_ce_8f_2c" &
+	 "cc_20_e4_f2_74_1f_b0_a3" &
+	 "3a_38_48_ae_c9_c9_30_5f" &
+	 "be_cb_d2_d7_68_19_96_7d" &
+	 "46_71_ac_c6_43_1e_40_37" &
+	 "96_8d_b3_78_78_e6_95_c1#");
+
+   DQ   : constant Big_Unsigned := To_Big_Unsigned
+     ("16#95_29_7b_0f_95_a2_fa_67" &
+         "d0_07_07_d6_09_df_d4_fc" & 
+	 "05_c8_9d_af_c2_ef_6d_6e" &
+	 "a5_5b_ec_77_1e_a3_33_73" &
+	 "4d_92_51_e7_90_82_ec_da" &
+	 "86_6e_fe_f1_3c_45_9e_1a" &
+	 "63_13_86_b7_e3_54_c8_99" &
+	 "f5_f1_12_ca_85_d7_15_83#");
+
+
+   QInv : constant Big_Unsigned := To_Big_Unsigned
+     ("16#4f_45_6c_50_24_93_bd_c0" &
+ 	 "ed_2a_b7_56_a3_a6_ed_4d" & 
+	 "67_35_2a_69_7d_42_16_e9" &
+	 "32_12_b1_27_a6_3d_54_11" &
+	 "ce_6f_a9_8d_5d_be_fd_73" &
+	 "26_3e_37_28_14_27_43_81" &
+	 "81_66_ed_7d_d6_36_87_dd" &
+	 "2a_8c_a1_d2_f4_fb_d8_e1#");
+
    Mess: constant RSA_Number :=
      (16#43#, 16#79#, 16#cf#, 16#00#, 16#3c#, 16#3b#, 16#74#, 16#0d#,
       16#d6#, 16#34#, 16#00#, 16#0c#, 16#4d#, 16#03#, 16#43#, 16#98#,
@@ -224,14 +259,21 @@ package body Test.RSA is
 
    procedure Test_Get_Private_Key(T : in out Test_Cases.Test_Case'Class) is
       NComp, DComp, PhiComp, PComp, QComp : RSA_Number;
+      DPComp, DQComp, QInvComp : RSA_Number;
       Sk  : Private_Key_RSA;
    begin
       Set_Private_Key(N, D, P, Q, Phi, Sk);
-      RSA.Get_Private_Key(Sk, NComp, DComp, PComp, QComp, PhiComp);
+      RSA.Get_Private_Key(Sk, NComp, DComp, PComp, QComp, PhiComp,
+			 DPComp, DQComp, QInvComp);
 
-      Assert(N = To_Big_Unsigned(NComp)   and D = To_Big_Unsigned(DComp) and  
-	       P = To_Big_Unsigned(PComp) and Q = To_Big_Unsigned(QComp) and
-	       Phi = To_Big_Unsigned(PhiComp), 
+      Assert(N    = To_Big_Unsigned(NComp) and
+	     D    = To_Big_Unsigned(DComp) and  
+	     P    = To_Big_Unsigned(PComp) and
+	     Q    = To_Big_Unsigned(QComp) and
+	     Phi  = To_Big_Unsigned(PhiComp) and
+	     DP   = To_Big_Unsigned(DPComp) and
+	     DQ   = To_Big_Unsigned(DQComp) and
+	     QInv = To_Big_Unsigned(QInvComp),
 	     "RSA_new Get Public/Private Key failed.");
    end Test_Get_Private_Key;
    


### PR DESCRIPTION
Hi Christian,
 Here's the pull request. As you can see, I've refactored Gen_RSA_Key a bit to make it simpler. I have also updated Check_Private_Key to check that the CRT forms are correct and P > Q. I've also updated Set_Private_Key and Get_Private_Key accordingly.

 I have updated the English version of the document, but not the German - sorry - I stopped studying German about 31 years ago... I think there may be a bug in the documentation regarding the conditions under which Constraint_Error is raised by Set_Private_Key - the code does TWO GCD checks, but the documentation only mentions one of them, and it look wrong anyway. I have marked the spot in the .tex file where that is.

 Oh - I've updated test/test-rsa.adb of course. You should find that all tests pass OK.

 All the best,
 Rod
